### PR TITLE
Adding imports to jdftx module's __init__ so I can start using this p…

### DIFF
--- a/src/pymatgen/io/jdftx/__init__.py
+++ b/src/pymatgen/io/jdftx/__init__.py
@@ -42,3 +42,8 @@ This folder is currently missing:
 - Sets
   - Common input sets are currently missing from the sets module.
 """
+
+from __future__ import annotations
+
+from pymatgen.io.jdftx.jdftxinfile import JDFTXInfile
+from pymatgen.io.jdftx.jdftxoutfile import JDFTXOutfile

--- a/tests/io/jdftx/test_imports.py
+++ b/tests/io/jdftx/test_imports.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+def test_JDFTXInfile():
+    from pymatgen.io import jdftx
+
+    assert hasattr(jdftx, "JDFTXInfile")
+
+
+def test_JDFTXOutfile():
+    from pymatgen.io import jdftx
+
+    assert hasattr(jdftx, "JDFTXOutfile")


### PR DESCRIPTION
…ymatgen fork as a dependency (anticipating the class objects not being kept in individual submodules for very long)