### PR TITLE
JDFTXOutfileSlice __getattr__ fix

### DIFF
--- a/src/pymatgen/io/jdftx/jdftxoutfileslice.py
+++ b/src/pymatgen/io/jdftx/jdftxoutfileslice.py
@@ -7,6 +7,7 @@ process a JDFTx out file.
 
 from __future__ import annotations
 
+import inspect
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -178,8 +179,8 @@ class JDFTXOutfileSlice(ClassPrintFormatter):
         """
         constant_lattice = False
         if self.jsettings_lattice is not None:
-            if self.jsettings_lattice.niterations is not None:
-                constant_lattice = self.jsettings_lattice.niterations == 0
+            if "niterations" in self.jsettings_lattice.params:
+                constant_lattice = int(self.jsettings_lattice.params["niterations"]) == 0
             else:
                 raise ValueError("Unknown issue due to partial initialization of settings objects.")
         return Trajectory.from_structures(structures=self.jstrucs, constant_lattice=constant_lattice)
@@ -1283,6 +1284,10 @@ class JDFTXOutfileSlice(ClassPrintFormatter):
         for field in self.__dataclass_fields__:
             value = getattr(self, field)
             dct[field] = value
+
+        # Include properties in the dictionary representation
+        for name, _obj in inspect.getmembers(type(self), lambda o: isinstance(o, property)):
+            dct[name] = getattr(self, name)
         return dct
 
     # This method is likely never going to be called as all (currently existing)
@@ -1306,8 +1311,25 @@ class JDFTXOutfileSlice(ClassPrintFormatter):
         """
         # The whole point of this is to be an unreached safety net, so expect hit
         # from coverage here
-        if name not in self.__dict__:
-            if not hasattr(self.jstrucs, name):
-                raise AttributeError(f"{self.__class__.__name__} not found: {name}")
+        # if name not in self.__dict__:
+        # if name not in inspect.getmembers(self):
+        #     if not hasattr(self.jstrucs, name):
+        #         raise AttributeError(f"{self.__class__.__name__} not found: {name}")
+        #     return getattr(self.jstrucs, name)
+        # return self.__dict__[name]
+        # Check if the attribute is in self.__dict__
+        # Check if the attribute is in self.__dict__
+        if name in self.__dict__:
+            return self.__dict__[name]
+
+        # Check if the attribute is a property of the class
+        for cls in inspect.getmro(self.__class__):
+            if name in cls.__dict__ and isinstance(cls.__dict__[name], property):
+                return cls.__dict__[name].__get__(self)
+
+        # Check if the attribute is in self.jstrucs
+        if hasattr(self.jstrucs, name):
             return getattr(self.jstrucs, name)
-        return self.__dict__[name]
+
+        # If the attribute is not found in either, raise an AttributeError
+        raise AttributeError(f"{self.__class__.__name__} not found: {name}")

--- a/src/pymatgen/io/jdftx/jdftxoutfileslice.py
+++ b/src/pymatgen/io/jdftx/jdftxoutfileslice.py
@@ -952,7 +952,7 @@ class JDFTXOutfileSlice(ClassPrintFormatter):
             settings object
         """
         settings_dict = self._create_settings_dict(text, settings_class.start_flag)
-        return settings_class(**settings_dict) if len(settings_dict) else None
+        return settings_class(params=settings_dict) if len(settings_dict) else None
 
     def set_min_settings(self, text: list[str]) -> None:
         """Set the settings objects from the out file text.
@@ -983,10 +983,11 @@ class JDFTXOutfileSlice(ClassPrintFormatter):
         self.set_min_settings(text)
         if self.jsettings_ionic is None or self.jsettings_lattice is None:
             raise ValueError("Unknown issue in setting settings objects")
-        if self.jsettings_lattice.niterations > 0:
+        if int(self.jsettings_lattice.params["niterations"]) > 0:
             self.geom_opt = True
             self.geom_opt_type = "lattice"
-        elif self.jsettings_ionic.niterations > 0:
+        elif int(self.jsettings_ionic.params["niterations"]) > 0:
+            # elif self.jsettings_ionic.niterations > 0:
             self.geom_opt = True
             self.geom_opt_type = "ionic"
         else:

--- a/src/pymatgen/io/jdftx/jminsettings.py
+++ b/src/pymatgen/io/jdftx/jminsettings.py
@@ -8,6 +8,7 @@ file.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -17,102 +18,21 @@ class JMinSettings:
     Store generic minimization settings read from a JDFTx out file.
     """
 
-    dirupdatescheme: str | None = None
-    linminmethod: str | None = None
-    niterations: int | None = None
-    history: int | None = None
-    knormthreshold: float | None = None
-    energydiffthreshold: float | None = None
-    nenergydiff: int | None = None
-    alphatstart: float | None = None
-    alphatmin: float | None = None
-    updateteststepsize: bool | None = None
-    alphatreducefactor: float | None = None
-    alphatincreasefactor: float | None = None
-    nalphaadjustmax: int | None = None
-    wolfeenergy: float | None = None
-    wolfegradient: float | None = None
-    fdtest: bool | None = None
-    maxthreshold: bool | None = None
-    start_flag: str | None = None
+    params: dict[str, Any] | None = None
 
     def __init__(
         self,
-        dirupdatescheme: str | None = None,
-        linminmethod: str | None = None,
-        niterations: int | None = None,
-        history: int | None = None,
-        knormthreshold: float | None = None,
-        energydiffthreshold: float | None = None,
-        nenergydiff: int | None = None,
-        alphatstart: float | None = None,
-        alphatmin: float | None = None,
-        updateteststepsize: bool | None = None,
-        alphatreducefactor: float | None = None,
-        alphatincreasefactor: float | None = None,
-        nalphaadjustmax: int | None = None,
-        wolfeenergy: float | None = None,
-        wolfegradient: float | None = None,
-        fdtest: bool | None = None,
-        maxthreshold: bool | None = None,
+        params: dict[str, Any] | None = None,
     ) -> None:
         """Initialize a generic JMInSettings class.
 
         Parameters
         ----------
-        dirupdatescheme : str
-            The direction update scheme used in the minimization.
-        linminmethod : str
-            The line minimization method used in the minimization.
-        niterations : int
-            The number of iterations used in the minimization.
-        history : int
-            The number of previous steps used in the minimization.
-        knormthreshold : float
-            The threshold for the norm of the gradient.
-        energydiffthreshold : float
-            The threshold for the energy difference.
-        nenergydiff : int
-            The number of energy differences.
-        alphatstart : float
-            The starting step size.
-        alphatmin : float
-            The minimum step size.
-        updateteststepsize : bool
-            Whether to update the step size.
-        alphatreducefactor : float
-            The factor by which to reduce the step size.
-        alphatincreasefactor : float
-            The factor by which to increase the step size.
-        nalphaadjustmax : int
-            The maximum number of step size adjustments.
-        wolfeenergy : float
-            The energy Wolfe condition.
-        wolfegradient : float
-            The gradient Wolfe condition.
-        fdtest : bool
-            Whether to use finite difference testing.
-        maxthreshold : bool
-            Whether to use the maximum threshold.
+        params : dict
+            A dictionary of minimization settings.
         """
         # pre-commit was not a fan of the _assign_type method
-        self.dirupdatescheme = None if dirupdatescheme is None else str(dirupdatescheme)
-        self.linminmethod = None if linminmethod is None else str(linminmethod)
-        self.niterations = None if niterations is None else int(niterations)
-        self.history = None if history is None else int(history)
-        self.knormthreshold = None if knormthreshold is None else float(knormthreshold)
-        self.energydiffthreshold = None if energydiffthreshold is None else float(energydiffthreshold)
-        self.nenergydiff = None if nenergydiff is None else int(nenergydiff)
-        self.alphatstart = None if alphatstart is None else float(alphatstart)
-        self.alphatmin = None if alphatmin is None else float(alphatmin)
-        self.updateteststepsize = None if updateteststepsize is None else bool(updateteststepsize)
-        self.alphatreducefactor = None if alphatreducefactor is None else float(alphatreducefactor)
-        self.alphatincreasefactor = None if alphatincreasefactor is None else float(alphatincreasefactor)
-        self.nalphaadjustmax = None if nalphaadjustmax is None else int(nalphaadjustmax)
-        self.wolfeenergy = None if wolfeenergy is None else float(wolfeenergy)
-        self.wolfegradient = None if wolfegradient is None else float(wolfegradient)
-        self.fdtest = None if fdtest is None else bool(fdtest)
-        self.maxthreshold = None if maxthreshold is None else bool(maxthreshold)
+        self.params = None if params is None else dict(params)
 
 
 @dataclass
@@ -127,43 +47,9 @@ class JMinSettingsElectronic(JMinSettings):
 
     def __init__(
         self,
-        dirupdatescheme: str | None = None,
-        linminmethod: str | None = None,
-        niterations: int | None = None,
-        history: int | None = None,
-        knormthreshold: float | None = None,
-        energydiffthreshold: float | None = None,
-        nenergydiff: int | None = None,
-        alphatstart: float | None = None,
-        alphatmin: float | None = None,
-        updateteststepsize: bool | None = None,
-        alphatreducefactor: float | None = None,
-        alphatincreasefactor: float | None = None,
-        nalphaadjustmax: int | None = None,
-        wolfeenergy: float | None = None,
-        wolfegradient: float | None = None,
-        fdtest: bool | None = None,
-        maxthreshold: bool | None = None,
+        params: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(
-            dirupdatescheme=dirupdatescheme,
-            linminmethod=linminmethod,
-            niterations=niterations,
-            history=history,
-            knormthreshold=knormthreshold,
-            energydiffthreshold=energydiffthreshold,
-            nenergydiff=nenergydiff,
-            alphatstart=alphatstart,
-            alphatmin=alphatmin,
-            updateteststepsize=updateteststepsize,
-            alphatreducefactor=alphatreducefactor,
-            alphatincreasefactor=alphatincreasefactor,
-            nalphaadjustmax=nalphaadjustmax,
-            wolfeenergy=wolfeenergy,
-            wolfegradient=wolfegradient,
-            fdtest=fdtest,
-            maxthreshold=maxthreshold,
-        )
+        super().__init__(params=params)
 
 
 @dataclass
@@ -178,43 +64,9 @@ class JMinSettingsFluid(JMinSettings):
 
     def __init__(
         self,
-        dirupdatescheme: str | None = None,
-        linminmethod: str | None = None,
-        niterations: int | None = None,
-        history: int | None = None,
-        knormthreshold: float | None = None,
-        energydiffthreshold: float | None = None,
-        nenergydiff: int | None = None,
-        alphatstart: float | None = None,
-        alphatmin: float | None = None,
-        updateteststepsize: bool | None = None,
-        alphatreducefactor: float | None = None,
-        alphatincreasefactor: float | None = None,
-        nalphaadjustmax: int | None = None,
-        wolfeenergy: float | None = None,
-        wolfegradient: float | None = None,
-        fdtest: bool | None = None,
-        maxthreshold: bool | None = None,
+        params: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(
-            dirupdatescheme=dirupdatescheme,
-            linminmethod=linminmethod,
-            niterations=niterations,
-            history=history,
-            knormthreshold=knormthreshold,
-            energydiffthreshold=energydiffthreshold,
-            nenergydiff=nenergydiff,
-            alphatstart=alphatstart,
-            alphatmin=alphatmin,
-            updateteststepsize=updateteststepsize,
-            alphatreducefactor=alphatreducefactor,
-            alphatincreasefactor=alphatincreasefactor,
-            nalphaadjustmax=nalphaadjustmax,
-            wolfeenergy=wolfeenergy,
-            wolfegradient=wolfegradient,
-            fdtest=fdtest,
-            maxthreshold=maxthreshold,
-        )
+        super().__init__(params=params)
 
 
 @dataclass
@@ -229,43 +81,9 @@ class JMinSettingsLattice(JMinSettings):
 
     def __init__(
         self,
-        dirupdatescheme: str | None = None,
-        linminmethod: str | None = None,
-        niterations: int | None = None,
-        history: int | None = None,
-        knormthreshold: float | None = None,
-        energydiffthreshold: float | None = None,
-        nenergydiff: int | None = None,
-        alphatstart: float | None = None,
-        alphatmin: float | None = None,
-        updateteststepsize: bool | None = None,
-        alphatreducefactor: float | None = None,
-        alphatincreasefactor: float | None = None,
-        nalphaadjustmax: int | None = None,
-        wolfeenergy: float | None = None,
-        wolfegradient: float | None = None,
-        fdtest: bool | None = None,
-        maxthreshold: bool | None = None,
+        params: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(
-            dirupdatescheme=dirupdatescheme,
-            linminmethod=linminmethod,
-            niterations=niterations,
-            history=history,
-            knormthreshold=knormthreshold,
-            energydiffthreshold=energydiffthreshold,
-            nenergydiff=nenergydiff,
-            alphatstart=alphatstart,
-            alphatmin=alphatmin,
-            updateteststepsize=updateteststepsize,
-            alphatreducefactor=alphatreducefactor,
-            alphatincreasefactor=alphatincreasefactor,
-            nalphaadjustmax=nalphaadjustmax,
-            wolfeenergy=wolfeenergy,
-            wolfegradient=wolfegradient,
-            fdtest=fdtest,
-            maxthreshold=maxthreshold,
-        )
+        super().__init__(params=params)
 
 
 @dataclass
@@ -280,40 +98,315 @@ class JMinSettingsIonic(JMinSettings):
 
     def __init__(
         self,
-        dirupdatescheme: str | None = None,
-        linminmethod: str | None = None,
-        niterations: int | None = None,
-        history: int | None = None,
-        knormthreshold: float | None = None,
-        energydiffthreshold: float | None = None,
-        nenergydiff: int | None = None,
-        alphatstart: float | None = None,
-        alphatmin: float | None = None,
-        updateteststepsize: bool | None = None,
-        alphatreducefactor: float | None = None,
-        alphatincreasefactor: float | None = None,
-        nalphaadjustmax: int | None = None,
-        wolfeenergy: float | None = None,
-        wolfegradient: float | None = None,
-        fdtest: bool | None = None,
-        maxthreshold: bool | None = None,
+        params: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(
-            dirupdatescheme=dirupdatescheme,
-            linminmethod=linminmethod,
-            niterations=niterations,
-            history=history,
-            knormthreshold=knormthreshold,
-            energydiffthreshold=energydiffthreshold,
-            nenergydiff=nenergydiff,
-            alphatstart=alphatstart,
-            alphatmin=alphatmin,
-            updateteststepsize=updateteststepsize,
-            alphatreducefactor=alphatreducefactor,
-            alphatincreasefactor=alphatincreasefactor,
-            nalphaadjustmax=nalphaadjustmax,
-            wolfeenergy=wolfeenergy,
-            wolfegradient=wolfegradient,
-            fdtest=fdtest,
-            maxthreshold=maxthreshold,
-        )
+        super().__init__(params=params)
+
+
+# @dataclass
+# class JMinSettings:
+#     """Store generic minimization settings read from a JDFTx out file.
+
+#     Store generic minimization settings read from a JDFTx out file.
+#     """
+
+#     dirupdatescheme: str | None = None
+#     linminmethod: str | None = None
+#     niterations: int | None = None
+#     history: int | None = None
+#     knormthreshold: float | None = None
+#     energydiffthreshold: float | None = None
+#     nenergydiff: int | None = None
+#     alphatstart: float | None = None
+#     alphatmin: float | None = None
+#     updateteststepsize: bool | None = None
+#     alphatreducefactor: float | None = None
+#     alphatincreasefactor: float | None = None
+#     nalphaadjustmax: int | None = None
+#     wolfeenergy: float | None = None
+#     wolfegradient: float | None = None
+#     fdtest: bool | None = None
+#     maxthreshold: bool | None = None
+#     start_flag: str | None = None
+
+#     def __init__(
+#         self,
+#         dirupdatescheme: str | None = None,
+#         linminmethod: str | None = None,
+#         niterations: int | None = None,
+#         history: int | None = None,
+#         knormthreshold: float | None = None,
+#         energydiffthreshold: float | None = None,
+#         nenergydiff: int | None = None,
+#         alphatstart: float | None = None,
+#         alphatmin: float | None = None,
+#         updateteststepsize: bool | None = None,
+#         alphatreducefactor: float | None = None,
+#         alphatincreasefactor: float | None = None,
+#         nalphaadjustmax: int | None = None,
+#         wolfeenergy: float | None = None,
+#         wolfegradient: float | None = None,
+#         fdtest: bool | None = None,
+#         maxthreshold: bool | None = None,
+#     ) -> None:
+#         """Initialize a generic JMInSettings class.
+
+#         Parameters
+#         ----------
+#         dirupdatescheme : str
+#             The direction update scheme used in the minimization.
+#         linminmethod : str
+#             The line minimization method used in the minimization.
+#         niterations : int
+#             The number of iterations used in the minimization.
+#         history : int
+#             The number of previous steps used in the minimization.
+#         knormthreshold : float
+#             The threshold for the norm of the gradient.
+#         energydiffthreshold : float
+#             The threshold for the energy difference.
+#         nenergydiff : int
+#             The number of energy differences.
+#         alphatstart : float
+#             The starting step size.
+#         alphatmin : float
+#             The minimum step size.
+#         updateteststepsize : bool
+#             Whether to update the step size.
+#         alphatreducefactor : float
+#             The factor by which to reduce the step size.
+#         alphatincreasefactor : float
+#             The factor by which to increase the step size.
+#         nalphaadjustmax : int
+#             The maximum number of step size adjustments.
+#         wolfeenergy : float
+#             The energy Wolfe condition.
+#         wolfegradient : float
+#             The gradient Wolfe condition.
+#         fdtest : bool
+#             Whether to use finite difference testing.
+#         maxthreshold : bool
+#             Whether to use the maximum threshold.
+#         """
+#         # pre-commit was not a fan of the _assign_type method
+#         self.dirupdatescheme = None if dirupdatescheme is None else str(dirupdatescheme)
+#         self.linminmethod = None if linminmethod is None else str(linminmethod)
+#         self.niterations = None if niterations is None else int(niterations)
+#         self.history = None if history is None else int(history)
+#         self.knormthreshold = None if knormthreshold is None else float(knormthreshold)
+#         self.energydiffthreshold = None if energydiffthreshold is None else float(energydiffthreshold)
+#         self.nenergydiff = None if nenergydiff is None else int(nenergydiff)
+#         self.alphatstart = None if alphatstart is None else float(alphatstart)
+#         self.alphatmin = None if alphatmin is None else float(alphatmin)
+#         self.updateteststepsize = None if updateteststepsize is None else bool(updateteststepsize)
+#         self.alphatreducefactor = None if alphatreducefactor is None else float(alphatreducefactor)
+#         self.alphatincreasefactor = None if alphatincreasefactor is None else float(alphatincreasefactor)
+#         self.nalphaadjustmax = None if nalphaadjustmax is None else int(nalphaadjustmax)
+#         self.wolfeenergy = None if wolfeenergy is None else float(wolfeenergy)
+#         self.wolfegradient = None if wolfegradient is None else float(wolfegradient)
+#         self.fdtest = None if fdtest is None else bool(fdtest)
+#         self.maxthreshold = None if maxthreshold is None else bool(maxthreshold)
+
+
+# @dataclass
+# class JMinSettingsElectronic(JMinSettings):
+#     """JMInSettings mutant for electronic minimization settings.
+
+#     A class for storing electronic minimization settings read from a
+#     JDFTx out file.
+#     """
+
+#     start_flag: str = "electronic-minimize"
+
+#     def __init__(
+#         self,
+#         dirupdatescheme: str | None = None,
+#         linminmethod: str | None = None,
+#         niterations: int | None = None,
+#         history: int | None = None,
+#         knormthreshold: float | None = None,
+#         energydiffthreshold: float | None = None,
+#         nenergydiff: int | None = None,
+#         alphatstart: float | None = None,
+#         alphatmin: float | None = None,
+#         updateteststepsize: bool | None = None,
+#         alphatreducefactor: float | None = None,
+#         alphatincreasefactor: float | None = None,
+#         nalphaadjustmax: int | None = None,
+#         wolfeenergy: float | None = None,
+#         wolfegradient: float | None = None,
+#         fdtest: bool | None = None,
+#         maxthreshold: bool | None = None,
+#     ) -> None:
+#         super().__init__(
+#             dirupdatescheme=dirupdatescheme,
+#             linminmethod=linminmethod,
+#             niterations=niterations,
+#             history=history,
+#             knormthreshold=knormthreshold,
+#             energydiffthreshold=energydiffthreshold,
+#             nenergydiff=nenergydiff,
+#             alphatstart=alphatstart,
+#             alphatmin=alphatmin,
+#             updateteststepsize=updateteststepsize,
+#             alphatreducefactor=alphatreducefactor,
+#             alphatincreasefactor=alphatincreasefactor,
+#             nalphaadjustmax=nalphaadjustmax,
+#             wolfeenergy=wolfeenergy,
+#             wolfegradient=wolfegradient,
+#             fdtest=fdtest,
+#             maxthreshold=maxthreshold,
+#         )
+
+
+# @dataclass
+# class JMinSettingsFluid(JMinSettings):
+#     """JMInSettings mutant for fluid minimization settings.
+
+#     A class for storing fluid minimization settings read from a
+#     JDFTx out file.
+#     """
+
+#     start_flag: str = "fluid-minimize"
+
+#     def __init__(
+#         self,
+#         dirupdatescheme: str | None = None,
+#         linminmethod: str | None = None,
+#         niterations: int | None = None,
+#         history: int | None = None,
+#         knormthreshold: float | None = None,
+#         energydiffthreshold: float | None = None,
+#         nenergydiff: int | None = None,
+#         alphatstart: float | None = None,
+#         alphatmin: float | None = None,
+#         updateteststepsize: bool | None = None,
+#         alphatreducefactor: float | None = None,
+#         alphatincreasefactor: float | None = None,
+#         nalphaadjustmax: int | None = None,
+#         wolfeenergy: float | None = None,
+#         wolfegradient: float | None = None,
+#         fdtest: bool | None = None,
+#         maxthreshold: bool | None = None,
+#     ) -> None:
+#         super().__init__(
+#             dirupdatescheme=dirupdatescheme,
+#             linminmethod=linminmethod,
+#             niterations=niterations,
+#             history=history,
+#             knormthreshold=knormthreshold,
+#             energydiffthreshold=energydiffthreshold,
+#             nenergydiff=nenergydiff,
+#             alphatstart=alphatstart,
+#             alphatmin=alphatmin,
+#             updateteststepsize=updateteststepsize,
+#             alphatreducefactor=alphatreducefactor,
+#             alphatincreasefactor=alphatincreasefactor,
+#             nalphaadjustmax=nalphaadjustmax,
+#             wolfeenergy=wolfeenergy,
+#             wolfegradient=wolfegradient,
+#             fdtest=fdtest,
+#             maxthreshold=maxthreshold,
+#         )
+
+
+# @dataclass
+# class JMinSettingsLattice(JMinSettings):
+#     """JMInSettings mutant for lattice minimization settings.
+
+#     A class for storing lattice minimization settings read from a
+#     JDFTx out file.
+#     """
+
+#     start_flag: str = "lattice-minimize"
+
+#     def __init__(
+#         self,
+#         dirupdatescheme: str | None = None,
+#         linminmethod: str | None = None,
+#         niterations: int | None = None,
+#         history: int | None = None,
+#         knormthreshold: float | None = None,
+#         energydiffthreshold: float | None = None,
+#         nenergydiff: int | None = None,
+#         alphatstart: float | None = None,
+#         alphatmin: float | None = None,
+#         updateteststepsize: bool | None = None,
+#         alphatreducefactor: float | None = None,
+#         alphatincreasefactor: float | None = None,
+#         nalphaadjustmax: int | None = None,
+#         wolfeenergy: float | None = None,
+#         wolfegradient: float | None = None,
+#         fdtest: bool | None = None,
+#         maxthreshold: bool | None = None,
+#     ) -> None:
+#         super().__init__(
+#             dirupdatescheme=dirupdatescheme,
+#             linminmethod=linminmethod,
+#             niterations=niterations,
+#             history=history,
+#             knormthreshold=knormthreshold,
+#             energydiffthreshold=energydiffthreshold,
+#             nenergydiff=nenergydiff,
+#             alphatstart=alphatstart,
+#             alphatmin=alphatmin,
+#             updateteststepsize=updateteststepsize,
+#             alphatreducefactor=alphatreducefactor,
+#             alphatincreasefactor=alphatincreasefactor,
+#             nalphaadjustmax=nalphaadjustmax,
+#             wolfeenergy=wolfeenergy,
+#             wolfegradient=wolfegradient,
+#             fdtest=fdtest,
+#             maxthreshold=maxthreshold,
+#         )
+
+
+# @dataclass
+# class JMinSettingsIonic(JMinSettings):
+#     """JMInSettings mutant for ionic minimization settings.
+
+#     A class for storing ionic minimization settings read from a
+#     JDFTx out file.
+#     """
+
+#     start_flag: str = "ionic-minimize"
+
+#     def __init__(
+#         self,
+#         dirupdatescheme: str | None = None,
+#         linminmethod: str | None = None,
+#         niterations: int | None = None,
+#         history: int | None = None,
+#         knormthreshold: float | None = None,
+#         energydiffthreshold: float | None = None,
+#         nenergydiff: int | None = None,
+#         alphatstart: float | None = None,
+#         alphatmin: float | None = None,
+#         updateteststepsize: bool | None = None,
+#         alphatreducefactor: float | None = None,
+#         alphatincreasefactor: float | None = None,
+#         nalphaadjustmax: int | None = None,
+#         wolfeenergy: float | None = None,
+#         wolfegradient: float | None = None,
+#         fdtest: bool | None = None,
+#         maxthreshold: bool | None = None,
+#     ) -> None:
+#         super().__init__(
+#             dirupdatescheme=dirupdatescheme,
+#             linminmethod=linminmethod,
+#             niterations=niterations,
+#             history=history,
+#             knormthreshold=knormthreshold,
+#             energydiffthreshold=energydiffthreshold,
+#             nenergydiff=nenergydiff,
+#             alphatstart=alphatstart,
+#             alphatmin=alphatmin,
+#             updateteststepsize=updateteststepsize,
+#             alphatreducefactor=alphatreducefactor,
+#             alphatincreasefactor=alphatincreasefactor,
+#             nalphaadjustmax=nalphaadjustmax,
+#             wolfeenergy=wolfeenergy,
+#             wolfegradient=wolfegradient,
+#             fdtest=fdtest,
+#             maxthreshold=maxthreshold,
+#         )

--- a/tests/io/jdftx/test_jdftxoutfileslice.py
+++ b/tests/io/jdftx/test_jdftxoutfileslice.py
@@ -70,7 +70,8 @@ def test_jdftxoutfileslice_trajectory():
     joutslice = JDFTXOutfileSlice.from_out_slice(ex_slice1)
     traj = joutslice.trajectory
     assert isinstance(traj, Trajectory)
-    joutslice.jsettings_lattice.niterations = None
+    del joutslice.jsettings_lattice.params["niterations"]
+    # joutslice.jsettings_lattice.params["niterations"] = None
     with pytest.raises(ValueError, match=re.escape("Unknown issue due to partial initialization of settings objects.")):
         traj = joutslice.trajectory
 


### PR DESCRIPTION
Previous version blocked access to properties defined for JDFTXOutfileSlice. This was not the case a month ago, but regardless now it is fixed.