### PR TITLE
input/output separation

### DIFF
--- a/src/pymatgen/io/jdftx/_input_utils.py
+++ b/src/pymatgen/io/jdftx/_input_utils.py
@@ -1,0 +1,38 @@
+"""Module for JDFTx IO module input utils.
+
+Module for JDFTx IO module input utils. Functions kept in this module are here if they are
+used by multiple submodules, or if they are anticipated to be used by multiple
+submodules in the future.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def flatten_list(tag: str, list_of_lists: list[Any]) -> list[Any]:
+    """Flatten list of lists into a single list, then stop.
+
+    Flatten list of lists into a single list, then stop.
+
+    Parameters
+    ----------
+    tag : str
+        The tag to flatten the list of lists for.
+    list_of_lists : list[Any]
+        The list of lists to flatten.
+
+    Returns
+    -------
+    list[Any]
+        The flattened list.
+    """
+    if not isinstance(list_of_lists, list):
+        raise TypeError(f"{tag}: You must provide a list to flatten_list()!")
+    flist = []
+    for v in list_of_lists:
+        if isinstance(v, list):
+            flist.extend(flatten_list(tag, v))
+        else:
+            flist.append(v)
+    return flist

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -1,6 +1,6 @@
-"""Module for JDFTx IO module utils.
+"""Module for JDFTx IO module output utils.
 
-Module for JDFTx IO module utils. Functions kept in this module are here if they are
+Module for JDFTx IO module output utils. Functions kept in this module are here if they are
 used by multiple submodules, or if they are anticipated to be used by multiple
 submodules in the future.
 

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -136,34 +136,6 @@ def multi_getattr(varbase: Any, varname: str):
     return varbase
 
 
-def flatten_list(tag: str, list_of_lists: list[Any]) -> list[Any]:
-    """Flatten list of lists into a single list, then stop.
-
-    Flatten list of lists into a single list, then stop.
-
-    Parameters
-    ----------
-    tag : str
-        The tag to flatten the list of lists for.
-    list_of_lists : list[Any]
-        The list of lists to flatten.
-
-    Returns
-    -------
-    list[Any]
-        The flattened list.
-    """
-    if not isinstance(list_of_lists, list):
-        raise TypeError(f"{tag}: You must provide a list to flatten_list()!")
-    flist = []
-    for v in list_of_lists:
-        if isinstance(v, list):
-            flist.extend(flatten_list(tag, v))
-        else:
-            flist.append(v)
-    return flist
-
-
 def _brkt_list_of_3_to_nparray(line: str) -> np.ndarray:
     """Return 3x1 numpy array.
 

--- a/src/pymatgen/io/jdftx/generic_tags.py
+++ b/src/pymatgen/io/jdftx/generic_tags.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import numpy as np
 
-from pymatgen.io.jdftx._utils import flatten_list
+from pymatgen.io.jdftx._input_utils import flatten_list
 
 __author__ = "Jacob Clary, Ben Rich"
 

--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -23,7 +23,7 @@ from monty.json import MSONable
 
 from pymatgen.core import Structure
 from pymatgen.core.periodic_table import Element
-from pymatgen.io.jdftx._utils import multi_getattr, multi_hasattr
+from pymatgen.io.jdftx._output_utils import multi_getattr, multi_hasattr
 from pymatgen.io.jdftx.generic_tags import AbstractTag, BoolTagContainer, DumpTagContainer, MultiformatTag, TagContainer
 from pymatgen.io.jdftx.jdftxinfile_master_format import (
     __PHONON_TAGS__,
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
     from typing_extensions import Self
 
-    from pymatgen.io.jdftx.jdftxoutfile import JDFTXOutfile
-    from pymatgen.io.jdftx.joutstructure import JOutStructure
     from pymatgen.util.typing import PathLike
 
 __author__ = "Jacob Clary, Ben Rich"
@@ -754,34 +752,38 @@ class JDFTXStructure(MSONable):
         )
         return cls(struct, selective_dynamics, sort_structure=sort_structure)
 
-    @classmethod
-    def from_jdftxoutfile(cls, jdftxoutfile: JDFTXOutfile) -> JDFTXStructure:
-        """Get JDFTXStructure from JDFTXOutfile.
+    # NOTE: The following methods are commented out so that the input and output sections of this code can be merged
+    # independently
+    # TODO: Uncomment these methods once the input and output sections of this code are merged, and add more methods
+    # to create input objects from output objects.
+    # @classmethod
+    # def from_jdftxoutfile(cls, jdftxoutfile: JDFTXOutfile) -> JDFTXStructure:
+    #     """Get JDFTXStructure from JDFTXOutfile.
 
-        Args:
-            jdftxoutfile (JDFTXOutfile): JDFTXOutfile object.
+    #     Args:
+    #         jdftxoutfile (JDFTXOutfile): JDFTXOutfile object.
 
-        Returns:
-            JDFTXStructure: The created JDFTXStructure object.
-        """
-        if not len(jdftxoutfile.jstrucs):
-            raise ValueError("No structures found in JDFTXOutfile")
-        joutstructure = jdftxoutfile.jstrucs[-1]
-        return cls.from_joutstructure(joutstructure)
+    #     Returns:
+    #         JDFTXStructure: The created JDFTXStructure object.
+    #     """
+    #     if not len(jdftxoutfile.jstrucs):
+    #         raise ValueError("No structures found in JDFTXOutfile")
+    #     joutstructure = jdftxoutfile.jstrucs[-1]
+    #     return cls.from_joutstructure(joutstructure)
 
-    @classmethod
-    def from_joutstructure(cls, joutstructure: JOutStructure) -> JDFTXStructure:
-        """Get JDFTXStructure from JOutStructure.
+    # @classmethod
+    # def from_joutstructure(cls, joutstructure: JOutStructure) -> JDFTXStructure:
+    #     """Get JDFTXStructure from JOutStructure.
 
-        Args:
-            joutstructure (JOutStructure): JOutStructure object.
+    #     Args:
+    #         joutstructure (JOutStructure): JOutStructure object.
 
-        Returns:
-            JDFTXStructure: The created JDFTXStructure object.
-        """
-        struct = Structure(joutstructure.lattice, joutstructure.species, joutstructure.coords)
-        selective_dynamics = joutstructure.selective_dynamics
-        return cls(struct, selective_dynamics, sort_structure=False)
+    #     Returns:
+    #         JDFTXStructure: The created JDFTXStructure object.
+    #     """
+    #     struct = Structure(joutstructure.lattice, joutstructure.species, joutstructure.coords)
+    #     selective_dynamics = joutstructure.selective_dynamics
+    #     return cls(struct, selective_dynamics, sort_structure=False)
 
     def get_str(self, in_cart_coords: bool = False) -> str:
         """Return a string to be written as JDFTXInfile tags.

--- a/src/pymatgen/io/jdftx/jdftxoutfileslice.py
+++ b/src/pymatgen/io/jdftx/jdftxoutfileslice.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.core.units import Ha_to_eV, ang_to_bohr
-from pymatgen.io.jdftx._utils import (
+from pymatgen.io.jdftx._output_utils import (
     find_all_key,
     find_first_range_key,
     find_key,

--- a/src/pymatgen/io/jdftx/jelstep.py
+++ b/src/pymatgen/io/jdftx/jelstep.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 from pymatgen.core.units import Ha_to_eV
-from pymatgen.io.jdftx._utils import get_colon_var_t1
+from pymatgen.io.jdftx._output_utils import get_colon_var_t1
 
 __author__ = "Ben Rich"
 

--- a/src/pymatgen/io/jdftx/joutstructure.py
+++ b/src/pymatgen/io/jdftx/joutstructure.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from pymatgen.core.structure import Lattice, Structure
 from pymatgen.core.units import Ha_to_eV, bohr_to_ang
-from pymatgen.io.jdftx._utils import (
+from pymatgen.io.jdftx._output_utils import (
     _brkt_list_of_3x3_to_nparray,
     correct_geom_opt_type,
     get_colon_var_t1,

--- a/src/pymatgen/io/jdftx/joutstructures.py
+++ b/src/pymatgen/io/jdftx/joutstructures.py
@@ -17,11 +17,11 @@ import numpy as np
 
 from pymatgen.core.structure import Structure
 from pymatgen.core.units import bohr_to_ang
-from pymatgen.io.jdftx._utils import correct_geom_opt_type, is_lowdin_start_line
+from pymatgen.io.jdftx._output_utils import correct_geom_opt_type, is_lowdin_start_line
 
 if TYPE_CHECKING:
     from pymatgen.io.jdftx.jelstep import JElSteps
-from pymatgen.io.jdftx._utils import find_first_range_key
+from pymatgen.io.jdftx._output_utils import find_first_range_key
 from pymatgen.io.jdftx.joutstructure import JOutStructure
 
 __author__ = "Ben Rich"

--- a/src/pymatgen/io/jdftx/outputs.py
+++ b/src/pymatgen/io/jdftx/outputs.py
@@ -15,7 +15,7 @@ import pprint
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from pymatgen.io.jdftx._utils import read_outfile_slices
+from pymatgen.io.jdftx._output_utils import read_outfile_slices
 from pymatgen.io.jdftx.jdftxoutfileslice import JDFTXOutfileSlice
 
 if TYPE_CHECKING:

--- a/tests/io/jdftx/test_utils.py
+++ b/tests/io/jdftx/test_utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from pymatgen.io.jdftx._utils import find_first_range_key, flatten_list, get_start_lines, multi_getattr, multi_hasattr
+from pymatgen.io.jdftx._input_utils import flatten_list
+from pymatgen.io.jdftx._output_utils import find_first_range_key, get_start_lines, multi_getattr, multi_hasattr
 from pymatgen.io.jdftx.joutstructures import _get_joutstructures_start_idx
 
 


### PR DESCRIPTION
Separating input and output pieces of the JDFTx IO module so that pull requests for each piece can be reviewed and merged independently. (This just amounts to commenting out two minor initialization methods for an inputs Structure mutant and splitting _utils.py into _input_utils.py and _output_utils.py)