### PR TITLE
Changing all "zopen" to just "open" due to an error raised when monty…

### DIFF
--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from monty.io import zopen
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -52,7 +51,7 @@ def read_file(file_name: str) -> list[str]:
     text: list[str]
         list of strings from file
     """
-    with zopen(file_name, "r") as f:
+    with open(file_name) as f:
         text = f.readlines()
     f.close()
     return text

--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy.constants as const
-from monty.io import zopen
 from monty.json import MSONable
 
 from pymatgen.core import Structure
@@ -185,7 +184,7 @@ class JDFTXInfile(dict, MSONable):
         Args:
             filename (PathLike): Filename to write to.
         """
-        with zopen(filename, mode="wt") as file:
+        with open(filename, mode="w") as file:
             file.write(str(self))
 
     @classmethod
@@ -211,7 +210,7 @@ class JDFTXInfile(dict, MSONable):
         path_parent = None
         if assign_path_parent:
             path_parent = Path(filename).parents[0]
-        with zopen(filename, mode="rt") as file:
+        with open(filename) as file:
             return cls.from_str(
                 file.read(),
                 dont_require_structure=dont_require_structure,
@@ -835,7 +834,7 @@ class JDFTXStructure(MSONable):
             filename (PathLike): Filename to write to.
             **kwargs: Kwargs to pass to JDFTXStructure.get_str.
         """
-        with zopen(filename, mode="wt") as file:
+        with open(filename, mode="w") as file:
             file.write(self.get_str(**kwargs))
 
     def as_dict(self) -> dict:

--- a/tests/files/io/jdftx/tmp/empty.txt
+++ b/tests/files/io/jdftx/tmp/empty.txt
@@ -1,1 +1,0 @@
-I am here to let github add this directory.

--- a/tests/io/jdftx/outputs_test_utils.py
+++ b/tests/io/jdftx/outputs_test_utils.py
@@ -21,14 +21,13 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-from .shared_test_utils import assert_same_value, dump_files_dir
+from .shared_test_utils import assert_same_value
 
-
-def write_mt_file(fname: str, write_dir: Path = dump_files_dir):
-    filepath = write_dir / fname
-    with open(filepath, "w") as f:
-        f.write("if you're reading this yell at ben")
-    f.close()
+# def write_mt_file(fname: str, write_dir: Path = dump_files_dir):
+#     filepath = write_dir / fname
+#     with open(filepath, "w") as f:
+#         f.write("if you're reading this yell at ben")
+#     f.close()
 
 
 def object_hasall_known_simple(obj: Any, knowndict: dict):

--- a/tests/io/jdftx/shared_test_utils.py
+++ b/tests/io/jdftx/shared_test_utils.py
@@ -5,6 +5,8 @@ This module will inherit everything from inputs_test_utils.py and outputs_test_u
 
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -31,3 +33,17 @@ def assert_same_value(testval, knownval):
         assert len(testval) == len(knownval)
         for i in range(len(testval)):
             assert_same_value(testval[i], knownval[i])
+
+
+@pytest.fixture(scope="module")
+def tmp_path():
+    os.mkdir(dump_files_dir)
+    yield dump_files_dir
+    shutil.rmtree(dump_files_dir)
+
+
+def write_mt_file(tmp_path: Path, fname: str):
+    filepath = tmp_path / fname
+    with open(filepath, "w") as f:
+        f.write("if you're reading this yell at ben")
+    f.close()

--- a/tests/io/jdftx/test_output_utils.py
+++ b/tests/io/jdftx/test_output_utils.py
@@ -10,8 +10,8 @@ from pymatgen.io.jdftx._output_utils import find_first_range_key, get_start_line
 from pymatgen.io.jdftx.joutstructures import _get_joutstructures_start_idx
 from pymatgen.io.jdftx.outputs import _find_jdftx_out_file
 
-from .outputs_test_utils import noeigstats_outfile_path, write_mt_file
-from .shared_test_utils import dump_files_dir
+from .outputs_test_utils import noeigstats_outfile_path
+from .shared_test_utils import write_mt_file
 
 
 def test_get_start_lines():
@@ -66,7 +66,7 @@ def test_get_joutstructures_start_idx():
     assert _get_joutstructures_start_idx(["ken", "ken"], out_slice_start_flag=start_flag) is None
 
 
-def test_find_jdftx_out_file():
+def test_find_jdftx_out_file(tmp_path):
     """Test the _find_jdftx_out_file function.
 
     This function is used to find the JDFTx out file in a directory.
@@ -74,18 +74,15 @@ def test_find_jdftx_out_file():
     and directories with multiple out files. And out file must match "*.out" or "out" exactly.
     """
     with pytest.raises(FileNotFoundError, match="No JDFTx out file found in directory."):
-        _find_jdftx_out_file(dump_files_dir)
-    write_mt_file("test.out")
-    assert _find_jdftx_out_file(dump_files_dir) == dump_files_dir / "test.out"
+        _find_jdftx_out_file(tmp_path)
+    write_mt_file(tmp_path, "test.out")
+    assert _find_jdftx_out_file(tmp_path) == tmp_path / "test.out"
     # out file has to match "*.out" or "out" exactly
-    write_mt_file("tinyout")
-    assert _find_jdftx_out_file(dump_files_dir) == dump_files_dir / "test.out"
-    remove(_find_jdftx_out_file(dump_files_dir))
-    write_mt_file("out")
-    assert _find_jdftx_out_file(dump_files_dir) == dump_files_dir / "out"
-    write_mt_file("tinyout.out")
+    write_mt_file(tmp_path, "tinyout")
+    assert _find_jdftx_out_file(tmp_path) == tmp_path / "test.out"
+    remove(_find_jdftx_out_file(tmp_path))
+    write_mt_file(tmp_path, "out")
+    assert _find_jdftx_out_file(tmp_path) == tmp_path / "out"
+    write_mt_file(tmp_path, "tinyout.out")
     with pytest.raises(FileNotFoundError, match="Multiple JDFTx out files found in directory."):
-        _find_jdftx_out_file(dump_files_dir)
-    # remove tmp files
-    for remaining in dump_files_dir.glob("*out"):
-        remove(remaining)
+        _find_jdftx_out_file(tmp_path)


### PR DESCRIPTION
….io tries to raise an "EncondingWarning", changing the dump files dir to be a fixture that creates itself, yields the path, and then removes itself (parts after a "yield" only run once the test using the fixture has finished)