### PR TITLE
phasing out TagContainer.multiline_tag since its redundant to TagCont…

### DIFF
--- a/src/pymatgen/io/jdftx/generic_tags.py
+++ b/src/pymatgen/io/jdftx/generic_tags.py
@@ -179,7 +179,8 @@ class AbstractTag(ClassPrintFormatter, ABC):
 
     def _write(self, tag: str, value: Any, multiline_override: bool = False, strip_override: bool = False) -> str:
         tag_str = f"{tag} " if self.write_tagname else ""
-        if self.multiline_tag or multiline_override:
+        # if self.multiline_tag or multiline_override:
+        if multiline_override:
             tag_str += "\\\n"
         if self.write_value:
             if not strip_override:
@@ -736,28 +737,30 @@ class TagContainer(AbstractTag):
         # Concatenate all subtag print values into a single string, with line breaks at appropriate
         # locations if needed
         for count, print_str in enumerate(print_str_list):
-            if self.multiline_tag:
-                final_value += f"{indent}{print_str}\\\n"
-            elif self.linebreak_nth_entry is not None:
+            # if self.multiline_tag:
+            #     final_value += f"{indent}{print_str}\\\n"
+            # elif self.linebreak_nth_entry is not None:
+            if self.linebreak_nth_entry is not None:
                 # handles special formatting with extra linebreak, e.g. for lattice tag
                 i_column = count % self.linebreak_nth_entry
                 if i_column == 0:
                     final_value += f"{indent}{print_str}"
-                elif i_column == self.linebreak_nth_entry - 1:
-                    final_value += f"{print_str}\\\n"
                 else:
                     final_value += f"{print_str}"
+                if i_column == self.linebreak_nth_entry - 1:
+                    final_value += "\\\n"
             else:
                 final_value += f"{print_str}"
-        if self.multiline_tag or self.linebreak_nth_entry is not None:  # handles special formatting for lattice tag
+        if self.linebreak_nth_entry is not None:  # handles special formatting for lattice tag
+            # if self.multiline_tag or self.linebreak_nth_entry is not None:
             final_value = final_value[:-2]  # exclude final \\n from final print call
 
         return self._write(
             tag,
             final_value,
             multiline_override=self.linebreak_nth_entry is not None,
-            # strip_override=(self.linebreak_nth_entry is not None),
-            strip_override=((self.linebreak_nth_entry is not None) or self.multiline_tag),
+            strip_override=(self.linebreak_nth_entry is not None),
+            # strip_override=((self.linebreak_nth_entry is not None) or self.multiline_tag),
         )
 
     def get_token_len(self) -> int:

--- a/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
@@ -251,7 +251,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             }
         ),
         "exchange-params": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "blockSize": IntTag(),
                 "nOuterVxx": IntTag(),
@@ -422,7 +423,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             }
         ),
         "electron-scattering": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "eta": FloatTag(optional=False),
                 "Ecut": FloatTag(),
@@ -586,25 +588,29 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
         ),
         "elec-eigen-algo": StrTag(options=["CG", "Davidson"]),
         "ionic-minimize": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 **deepcopy(jdftxminimize_subtagdict),
             },
         ),
         "lattice-minimize": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 **deepcopy(jdftxminimize_subtagdict),
             },
         ),
         "electronic-minimize": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 **deepcopy(jdftxminimize_subtagdict),
             },
         ),
         "electronic-scf": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "energyDiffThreshold": FloatTag(),
                 "history": IntTag(),
@@ -622,7 +628,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             },
         ),
         "fluid-minimize": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 **deepcopy(jdftxminimize_subtagdict),
             },
@@ -636,7 +643,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             }
         ),
         "perturb-minimize": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "algorithm": StrTag(options=["MINRES", "CGIMINRES"]),
                 "CGBypass": BoolTag(),
@@ -819,7 +827,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
         ),
         "fluid-solve-frequency": StrTag(options=["Default", "Gummel", "Inner"]),
         "fluid-site-params": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             can_repeat=True,
             subtags={
                 "component": StrTag(
@@ -872,7 +881,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             ]
         ),
         "pcm-nonlinear-scf": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "energyDiffThreshold": FloatTag(),
                 "history": IntTag(),
@@ -883,7 +893,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             },
         ),
         "pcm-params": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "cavityFile": StrTag(),
                 "cavityPressure": FloatTag(),
@@ -943,7 +954,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             }
         ),
         "ionic-dynamics": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "B0": FloatTag(),
                 "chainLengthP": FloatTag(),
@@ -989,8 +1001,7 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             }
         ),
         "density-of-states": TagContainer(
-            multiline_tag=False,
-            linebreak_nth_entry=5,
+            linebreak_nth_entry=1,
             subtags={
                 "Total": BoolTag(write_value=False),
                 "Slice": TagContainer(
@@ -1079,7 +1090,8 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
             ],
         ),
         "bgw-params": TagContainer(
-            multiline_tag=True,
+            linebreak_nth_entry=1,
+            multiline_tag=False,
             subtags={
                 "nBandsDense": IntTag(),
                 "nBandsV": IntTag(),


### PR DESCRIPTION
…ainer.linebreath_nth_entry == 1, fixing oversight for linebreath_nth_entry == 1 case which was causing new lines from getting an indent