### PR TITLE
Multiformat lattice tag

### DIFF
--- a/src/pymatgen/io/jdftx/generic_tags.py
+++ b/src/pymatgen/io/jdftx/generic_tags.py
@@ -691,6 +691,8 @@ class TagContainer(AbstractTag):
                         tempdict[subtag].append(subtag_type.read(subtag, subtag_value))
                         del value_list[idx_start:idx_end]
 
+        # TODO: This breaks for TagContainers with optional StrTags that are not at the end of the line (ie
+        # modification subtag for lattice tag). We need to figure out a fix.
         for subtag, subtag_type in (
             (subtag, subtag_type) for subtag, subtag_type in self.subtags.items() if not subtag_type.write_tagname
         ):

--- a/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
@@ -65,22 +65,89 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
         ),
         "coords-type": StrTag(options=["Cartesian", "Lattice"]),
         # TODO: change lattice tag into MultiformatTag for different symmetry options
-        "lattice": TagContainer(
-            linebreak_nth_entry=3,
+        "lattice": MultiformatTag(
+            can_repeat=False,
             optional=False,
-            allow_list_representation=True,
-            subtags={
-                "R00": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R01": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R02": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R10": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R11": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R12": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R20": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R21": FloatTag(write_tagname=False, optional=False, prec=12),
-                "R22": FloatTag(write_tagname=False, optional=False, prec=12),
-            },
+            format_options=[
+                # Explicitly define the lattice vectors
+                TagContainer(
+                    linebreak_nth_entry=3,
+                    allow_list_representation=True,
+                    subtags={
+                        "R00": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R01": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R02": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R10": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R11": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R12": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R20": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R21": FloatTag(write_tagname=False, optional=False, prec=12),
+                        "R22": FloatTag(write_tagname=False, optional=False, prec=12),
+                    },
+                ),
+                TagContainer(
+                    subtags={
+                        "Triclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "b": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                        "alpha": FloatTag(write_tagname=False, optional=False),
+                        "beta": FloatTag(write_tagname=False, optional=False),
+                        "gamma": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                # TagContainer(
+                #     subtags={
+                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                #     }
+                # )
+                # TagContainer(
+                #     subtags={
+                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                #     }
+                # )
+                # TagContainer(
+                #     subtags={
+                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                #     }
+                # )
+                TagContainer(
+                    subtags={
+                        "Rhombohedral": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "alpha": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "Hexagonal": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                # TagContainer(
+                #     subtags={
+                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                #     }
+                # )
+            ],
         ),
+        # "lattice": TagContainer(
+        #     linebreak_nth_entry=3,
+        #     optional=False,
+        #     allow_list_representation=True,
+        #     subtags={
+        #         "R00": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R01": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R02": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R10": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R11": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R12": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R20": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R21": FloatTag(write_tagname=False, optional=False, prec=12),
+        #         "R22": FloatTag(write_tagname=False, optional=False, prec=12),
+        #     },
+        # ),
         "ion": TagContainer(
             can_repeat=True,
             optional=False,
@@ -1235,4 +1302,3 @@ def get_tag_object(tag: str) -> AbstractTag:
         AbstractTag: The tag object.
     """
     return MASTER_TAG_LIST[__TAG_GROUPS__[tag]][tag]
-

--- a/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
@@ -96,21 +96,80 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
                         "gamma": FloatTag(write_tagname=False, optional=False),
                     }
                 ),
-                # TagContainer(
-                #     subtags={
-                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
-                #     }
-                # )
-                # TagContainer(
-                #     subtags={
-                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
-                #     }
-                # )
-                # TagContainer(
-                #     subtags={
-                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
-                #     }
-                # )
+                TagContainer(
+                    subtags={
+                        "modification": StrTag(
+                            options=["Base-Centered"],  # Single-option modification could be a boolean tag, but keeping
+                            # as a string tagfor consistency with the other modified lattice tags
+                            optional=False,
+                            write_tagname=False,
+                            write_value=True,
+                        ),
+                        "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "b": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                        "beta": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                # This is a duplicate of the above tag, but without the modification subtag.
+                # This is not an elegant solution, but this approach only adds < 50 lines of code. The long term fix
+                # will be to make major changes to the TagContainer `read` implementation in the way it expects
+                # values to be ordered/present after parsing subtags with write_tagname=True.
+                # Another option would be to make all modification options boolean tags, but this would allow mutually
+                # exclusive tags to be present in the same tag, which is not ideal.
+                TagContainer(
+                    subtags={
+                        "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "b": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                        "beta": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "modification": StrTag(
+                            options=["Base-Centered", "Body-Centered", "Face-Centered"],
+                            optional=False,
+                            write_tagname=False,
+                            write_value=True,
+                        ),
+                        "Orthorhombic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "b": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "Orthorhombic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "b": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "modification": StrTag(
+                            options=["Body-Centered"],  # This could be a boolean tag, but keeping a string tag
+                            # for consistency with the other modified lattice tags
+                            optional=False,
+                            write_tagname=False,
+                            write_value=True,
+                        ),
+                        "Tetragonal": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "Tetragonal": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                        "c": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
                 TagContainer(
                     subtags={
                         "Rhombohedral": BoolTag(write_tagname=True, optional=False, write_value=False),
@@ -125,11 +184,24 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
                         "c": FloatTag(write_tagname=False, optional=False),
                     }
                 ),
-                # TagContainer(
-                #     subtags={
-                #         "Monoclinic": BoolTag(write_tagname=True, optional=False, write_value=False),
-                #     }
-                # )
+                TagContainer(
+                    subtags={
+                        "modification": StrTag(
+                            options=["Body-Centered", "Face-Centered"],
+                            optional=False,
+                            write_tagname=False,
+                            write_value=True,
+                        ),
+                        "Cubic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
+                TagContainer(
+                    subtags={
+                        "Cubic": BoolTag(write_tagname=True, optional=False, write_value=False),
+                        "a": FloatTag(write_tagname=False, optional=False),
+                    }
+                ),
             ],
         ),
         # "lattice": TagContainer(

--- a/tests/io/jdftx/test_jdftxinfile.py
+++ b/tests/io/jdftx/test_jdftxinfile.py
@@ -249,6 +249,10 @@ def test_jdftxstructure():
     assert isinstance(struct, JDFTXStructure)
     struc_str = str(struct)
     assert isinstance(struc_str, str)
+    newstruct = JDFTXStructure.from_str(struc_str)
+    assert isinstance(newstruct, JDFTXStructure)
+    # Double checking I got the column/row order right
+    assert_same_value(struct.structure.lattice, newstruct.structure.lattice)
     assert struct.natoms == 16
     with open(ex_infile2_fname) as f:
         lines = list.copy(list(f))

--- a/tests/io/jdftx/test_lattice_tag.py
+++ b/tests/io/jdftx/test_lattice_tag.py
@@ -1,0 +1,47 @@
+# Temporary test module for turning lattice tag into mutiformat tag
+
+from __future__ import annotations
+
+import pytest
+
+from pymatgen.io.jdftx.jdftxinfile_master_format import get_tag_object
+
+from .shared_test_utils import assert_same_value
+
+
+@pytest.mark.parametrize(
+    ("lattice_type", "value_str"),
+    [
+        ("Rhombohedral", "Rhombohedral 1.0 1.0"),
+        ("Triclinic", "Triclinic 1.0 1.0 1.0 1.0 1.0 1.0"),
+        ("Hexagonal", "Hexagonal 1.0 1.0"),
+    ],
+)
+def test_lattice_reading(lattice_type: str, value_str: str):
+    mft_lattice_tag = get_tag_object("lattice")
+    assert mft_lattice_tag is not None
+    i = mft_lattice_tag.get_format_index_for_str_value("lattice", value_str)
+    tag_object = mft_lattice_tag.format_options[i]
+    parsed_tag = tag_object.read("lattice", value_str)
+    assert lattice_type in parsed_tag
+
+
+@pytest.mark.parametrize(
+    ("value_str"),
+    [
+        ("Rhombohedral 1.0 1.0"),
+        ("Triclinic 1.0 1.0 1.0 1.0 1.0 1.0"),
+        ("Hexagonal 1.0 1.0"),
+    ],
+)
+def test_lattice_writing(value_str: str):
+    mft_lattice_tag = get_tag_object("lattice")
+    assert mft_lattice_tag is not None
+    i = mft_lattice_tag.get_format_index_for_str_value("lattice", value_str)
+    tag_object = mft_lattice_tag.format_options[i]
+    parsed_tag = tag_object.read("lattice", value_str)
+    output = tag_object.write("lattice", parsed_tag)
+    assert_same_value(
+        ("lattice " + value_str).strip().split(),
+        output.strip().split(),
+    )

--- a/tests/io/jdftx/test_lattice_tag.py
+++ b/tests/io/jdftx/test_lattice_tag.py
@@ -15,6 +15,8 @@ from .shared_test_utils import assert_same_value
         ("Rhombohedral", "Rhombohedral 1.0 1.0"),
         ("Triclinic", "Triclinic 1.0 1.0 1.0 1.0 1.0 1.0"),
         ("Hexagonal", "Hexagonal 1.0 1.0"),
+        ("Cubic", "Body-Centered Cubic 1.0"),
+        ("Cubic", "Cubic 1.0"),
     ],
 )
 def test_lattice_reading(lattice_type: str, value_str: str):
@@ -32,6 +34,14 @@ def test_lattice_reading(lattice_type: str, value_str: str):
         ("Rhombohedral 1.0 1.0"),
         ("Triclinic 1.0 1.0 1.0 1.0 1.0 1.0"),
         ("Hexagonal 1.0 1.0"),
+        ("Body-Centered Cubic 1.0"),
+        ("Cubic 1.0"),
+        ("Orthorhombic 1.0 1.0 1.0"),
+        ("Base-Centered Orthorhombic 1.0 1.0 1.0"),
+        ("Monoclinic 1.0 1.0 1.0 1.0"),
+        ("Base-Centered Monoclinic 1.0 1.0 1.0 1.0"),
+        ("Tetragonal 1.0 1.0"),
+        ("Body-Centered Tetragonal 1.0 1.0"),
     ],
 )
 def test_lattice_writing(value_str: str):
@@ -45,3 +55,24 @@ def test_lattice_writing(value_str: str):
         ("lattice " + value_str).strip().split(),
         output.strip().split(),
     )
+
+
+# This fails, but I don't think we need to support this
+# @pytest.mark.parametrize(
+#     ("unordered_dict", "expected_out"),
+#     [
+#         (
+#             {"a": 1.0, "Cubic-type": "Body-Centered", "Cubic": True},
+#             "Body-Centered Cubic 1.0",
+#         ),
+#     ],
+# )
+# def test_arg_ordering(unordered_dict, expected_out):
+#     mft_lattice_tag = get_tag_object("lattice")
+#     i = mft_lattice_tag.get_format_index_for_str_value("lattice", expected_out)
+#     tag_object = mft_lattice_tag.format_options[i]
+#     output = tag_object.write("lattice", unordered_dict)
+#     assert_same_value(
+#         ("lattice " + expected_out).strip().split(),
+#         output.strip().split(),
+#     )


### PR DESCRIPTION
Changing the tag for "lattice" from a `TagContainer` to a `MultiformatTag` - this has revealed an oversight in `read` implementation for `TagContainer` that is not problematic for now but should be fixed eventually.