### PR TITLE
Adding `NotImplementedError` for Structure <-> JDFTXInfile conversion…

### DIFF
--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -789,6 +789,11 @@ class JDFTXStructure(MSONable):
             JDFTXStructure: The created JDFTXStructure object.
         """
         jl = jdftxinfile["lattice"]
+        if "R00" not in jl:
+            raise NotImplementedError(
+                "JDFTXStructure construction from JDFTXInfile currently only implemented for "
+                "lattices defined as a 3x3 matrix. "
+            )
         lattice = np.zeros([3, 3])
         for i in range(3):
             for j in range(3):


### PR DESCRIPTION
… for JDFTXInfile with special case lattices (aka lattices not provided as a 3x3 matrix)