### PR TITLE
Misc edits

### DIFF
--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -433,7 +433,7 @@ class JDFTXInfile(dict, MSONable):
         """
         # Wasn't working before
         # return type(self)(self)
-        return self.from_dict(self.as_dict(skip_module_keys=True))
+        return self.from_dict(self.as_dict(skip_module_keys=True), validate_value_boundaries=False)
 
     def get_text_list(self) -> list[str]:
         """Get a list of strings representation of the JDFTXInfile.

--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -21,7 +21,14 @@ from monty.json import MSONable
 from pymatgen.core import Lattice, Structure
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.units import bohr_to_ang
-from pymatgen.io.jdftx.generic_tags import AbstractTag, BoolTagContainer, DumpTagContainer, MultiformatTag, TagContainer
+from pymatgen.io.jdftx.generic_tags import (
+    AbstractTag,
+    BoolTagContainer,
+    DumpTagContainer,
+    FloatTag,
+    MultiformatTag,
+    TagContainer,
+)
 from pymatgen.io.jdftx.jdftxinfile_default_inputs import default_inputs
 from pymatgen.io.jdftx.jdftxinfile_master_format import (
     __PHONON_TAGS__,
@@ -45,14 +52,15 @@ if TYPE_CHECKING:
 
 __author__ = "Jacob Clary, Ben Rich"
 
+
 # TODO: Add check for whether all ions have or lack velocities.
 # TODO: Add default value filling like JDFTx does.
 # TODO: Add more robust checking for if two repeatable tag values represent the
 # same information. This is likely fixed by implementing filling of default values.
 # TODO: Incorporate something to collapse repeated dump tags of the same frequency
 # into a single value.
-
-
+# TODO: Add a method to strip all tags that contain their default values for simpler
+# files written (especially when a `JDFTXInfile` is created from `JDFTXOutfileSlice`)
 class JDFTXInfile(dict, MSONable):
     """Class for reading/writing JDFtx input files.
 
@@ -270,6 +278,32 @@ class JDFTXInfile(dict, MSONable):
         jstr = jdftxstructure.get_str()
         return cls.from_str(jstr)
 
+    def read_line(
+        self,
+        line: str,
+        validate_value_boundaries: bool = True,
+        autofix: bool = True,
+        overwrite_nonrepeatable: bool = True,
+    ) -> None:
+        """Read a single line and update the JDFTXInfile object.
+
+        Convenience method for reading a single line and updating the JDFTXInfile object.
+
+        Args:
+            line (str): Line to read.
+        """
+        line = line.strip()
+        tag_object, tag, value = self._preprocess_line(line)
+        if not tag_object.can_repeat and overwrite_nonrepeatable and tag in self:
+            del self[tag]
+        processed_value = tag_object.read(tag, value)
+        _params = self.as_dict(skip_module_keys=True)
+        _params = self._store_value(_params, tag_object, tag, processed_value)
+        self.update(_params)
+        self.validate_tags(try_auto_type_fix=autofix, error_on_failed_fix=True)
+        if validate_value_boundaries:
+            self.validate_boundaries()
+
     @classmethod
     def from_str(
         cls,
@@ -397,7 +431,9 @@ class JDFTXInfile(dict, MSONable):
         Returns:
             JDFTXInfile: Copy of the JDFTXInfile object.
         """
-        return type(self)(self)
+        # Wasn't working before
+        # return type(self)(self)
+        return self.from_dict(self.as_dict(skip_module_keys=True))
 
     def get_text_list(self) -> list[str]:
         """Get a list of strings representation of the JDFTXInfile.
@@ -426,14 +462,24 @@ class JDFTXInfile(dict, MSONable):
                 text.append("")
         return text
 
-    def write_file(self, filename: PathLike) -> None:
+    # TODO: JDFTXInfile can accept nan for values, as this is occasionally what is stored
+    # for unused variables, but JDFTx has no way read nan for an input value. All subtags
+    # with nan values should be removed before writing to file.
+    # TODO: Detect for and warn for tags that can be used together but likely shouldn't be,
+    # ie (ion-width being 0 while fluid is not None)
+    def write_file(self, filename: PathLike, strip_nan: bool = False) -> None:
         """Write JDFTXInfile to an in file.
 
         Args:
             filename (PathLike): Filename to write to.
+            strip_nan (bool, optional): Whether to strip all subtags with nan values before writing.
+                                         Defaults to False. WARNING - VERY JANKY RIGHT NOW
         """
+        write_infile = self
+        if strip_nan:
+            write_infile = clean_infile_of_nans(self)
         with open(filename, mode="w") as file:
-            file.write(str(self))
+            file.write(str(write_infile))
 
     @classmethod
     def to_jdftxstructure(
@@ -910,6 +956,107 @@ def movescale_array_to_selective_dynamics_site_prop(movescale: ArrayLike[int | f
         bool_v = bool(scale)
         selective_dynamics.append([bool_v, bool_v, bool_v])
     return selective_dynamics
+
+
+# def _strip_nans(infile: JDFTXInfile) -> JDFTXInfile:
+#     for k, v in infile.items():
+#         tag_object = get_tag_object_on_val(k, v)
+#         if isinstance(v, dict):
+#             infile[k] = _strip_nans(v)
+#         if isinstance(v, float) and np.isnan(v):
+#             infile[k] = None
+#         elif isinstance(v, list):
+#             infile[k] = [x for x in v if not (isinstance(x, float) and np.isnan(x))]
+#         elif isinstance(v, dict):
+#             infile[k] = _strip_nans(v)
+
+# def _has_nans(value: float | list) -> bool:
+#     if isinstance(value, float) and np.isnan(value):
+#         return True
+#     elif isinstance(value, list):
+#         return any(_has_nans(x) for x in value)
+#     return False
+
+
+def _isnan(x):
+    try:
+        return np.isnan(x)
+    except TypeError:
+        return False
+
+
+def _check_tagcontainer_for_nan(tag_container: TagContainer, val_dict: dict):
+    hasnans = []
+    for kk, vv in val_dict.items():
+        tag = tag_container.subtags[kk]
+        if not isinstance(tag, TagContainer):
+            if _isnan(vv):
+                print(f"Tag {kk} has nan value")
+                hasnans.append(kk)
+        elif not tag.can_repeat:
+            _hasnans = _check_tagcontainer_for_nan(tag, vv)
+            if len(_hasnans) > 0:
+                hasnans.append({kk: _hasnans})
+    return hasnans
+
+
+def has_nan_in_required_subtag(tag_container: TagContainer, val_dict: dict):
+    for kk, vv in val_dict.items():
+        tag = tag_container.subtags[kk]
+        if not isinstance(tag, TagContainer):
+            if _isnan(vv) and not tag.optional:
+                return True
+        elif not tag.can_repeat and has_nan_in_required_subtag(tag, vv):
+            return True
+    return False
+
+
+def clean_tagcontainer_of_nans(tag_container: TagContainer, val_dict: dict):
+    subtags_to_delete = []
+    for kk, vv in val_dict.items():
+        tag = tag_container.subtags[kk]
+        if not isinstance(tag, TagContainer):
+            if _isnan(vv):
+                print(f"Removing tag {kk} with nan value")
+                subtags_to_delete.append(kk)
+        elif not tag.can_repeat:
+            if has_nan_in_required_subtag(tag, vv) and tag_container.optional:
+                subtags_to_delete.append(kk)
+            else:
+                clean_tagcontainer_of_nans(tag, vv)
+                if len(tag.subtags) == 0:
+                    print(f"Removing empty tag container {kk}")
+                    subtags_to_delete.append(kk)
+            clean_tagcontainer_of_nans(tag, vv)
+    for kk in subtags_to_delete:
+        val_dict.pop(kk)
+
+
+def clean_infile_of_nans(infile: JDFTXInfile) -> JDFTXInfile:
+    hasnans = []
+    for k, v in infile.items():
+        tag = get_tag_object_on_val(k, v)
+        if isinstance(tag, FloatTag) and _isnan(v):
+            print(f"Tag {k} has nan value")
+        elif isinstance(tag, TagContainer) and not tag.can_repeat:
+            _hasnans = _check_tagcontainer_for_nan(tag, v)
+            if len(_hasnans) > 0:
+                hasnans.append({k: _hasnans})
+    infile_cleaned = JDFTXInfile.from_dict(infile.as_dict())
+
+    # infile_cleaned = JDFTXInfile(infile)
+
+    for h in hasnans:
+        if isinstance(h, str):
+            infile_cleaned.pop(h)
+        elif isinstance(h, dict):
+            for _h in h:
+                tag = get_tag_object_on_val(_h, infile_cleaned[_h])
+                if _isnan(infile_cleaned[_h]):
+                    infile_cleaned.pop(_h)
+                else:
+                    clean_tagcontainer_of_nans(tag, infile_cleaned[_h])
+    return infile_cleaned
 
 
 @dataclass

--- a/src/pymatgen/io/jdftx/jdftxinfile_default_inputs.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_default_inputs.py
@@ -7,6 +7,7 @@ import numpy as np
 # One example is fluid-minimize, which has different convergence thresholds and max iterations depending
 # on the algorithm specified. For these tags, a second set of default values which can map partially
 # filled tagcontainers to the set as filled by JDFTx is needed.
+# TODO: Make sure ion-width, which changes based on 'fluid' tag, is handled correctly.
 default_inputs = {
     "basis": "kpoint-dependent",
     "coords-type": "Lattice",

--- a/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_master_format.py
@@ -574,7 +574,7 @@ MASTER_TAG_LIST: dict[str, dict[str, Any]] = {
                     write_tagname=False,
                     optional=False,
                 ),
-                "origin": TagContainer(
+                "center": TagContainer(
                     allow_list_representation=True,
                     optional=True,
                     subtags={

--- a/src/pymatgen/io/jdftx/joutstructures.py
+++ b/src/pymatgen/io/jdftx/joutstructures.py
@@ -154,6 +154,8 @@ class JOutStructures:
     def _from_out_slice(
         cls,
         out_slice: list[str],
+        # skim_levels: list[str],
+        # skip_props: list[str] | None = None,
         opt_type: str = "IonicMinimize",
         init_struc: Structure | None = None,
         is_md: bool = False,
@@ -430,7 +432,15 @@ def _get_joutstructure_list(
         # If this is changed to always be the first structure, logic down the line on what is considered
         # a "single point" calculation will be broken.
         joutstructure_list.append(
-            JOutStructure._from_text_slice([], init_structure=init_structure, opt_type=opt_type, is_md=is_md)
+            JOutStructure._from_text_slice(
+                [],
+                init_structure=init_structure,
+                opt_type=opt_type,
+                is_md=is_md,
+                expected_etype=expected_etype,
+                skim_levels=skim_levels,
+                skip_props=skip_props,
+            )
         )
     if skim_levels is not None and "geom" in skim_levels:
         for bounds in out_bounds[::-1]:

--- a/tests/io/jdftx/test_jdftxinfile.py
+++ b/tests/io/jdftx/test_jdftxinfile.py
@@ -172,9 +172,11 @@ def test_JDFTXInfile_expected_exceptions():
     with pytest.raises(ValueError, match=re.escape(err_str)):
         # Implicitly tests validate_tags
         jif[tag] = value
+    # `copy` will end up trying to validate the tags, so we need to remove the offending tag first
+    jif.pop(tag)
+    jif2 = jif.copy()
     # Setting tags with unfixable values through "update" side-steps the error, but will raise it once
     # "validate_tags" is inevitably called
-    jif2 = jif.copy()
     jif2.update({tag: value})
     with pytest.raises(ValueError, match=re.escape(err_str)):
         jif2.validate_tags(try_auto_type_fix=True)

--- a/tests/io/jdftx/test_jdftxoutfile.py
+++ b/tests/io/jdftx/test_jdftxoutfile.py
@@ -187,7 +187,8 @@ def test_none_on_partial(ex_outfile_path: Path):
     texts0 = texts[:-1]
 
     slices = [
-        JDFTXOutfileSlice._from_out_slice(text, is_bgw=False, none_on_error=False) for i, text in enumerate(texts0)
+        JDFTXOutfileSlice._from_out_slice(text, [], [], is_bgw=False, none_on_error=False)
+        for i, text in enumerate(texts0)
     ]
     outfile1 = JDFTXOutfile(slices=slices)
     slices.append(None)

--- a/tests/io/jdftx/test_jdftxoutfileslice.py
+++ b/tests/io/jdftx/test_jdftxoutfileslice.py
@@ -13,26 +13,26 @@ from .outputs_test_utils import ex_outfileslice1 as ex_slice1
 
 
 def test_jdftxoutfileslice_stringify():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     out_str = str(joutslice)
     assert isinstance(out_str, str)
     assert out_str
 
 
 def test_jdftxoutfileslice_converge():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     assert joutslice.converged
 
 
 def test_jdftxoutfileslice_trajectory():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     traj = joutslice.trajectory
     assert isinstance(traj, Trajectory)
     assert len(traj) == len(joutslice.jstrucs)
 
 
 def test_get_broadeningvars():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     btype = "btype"
     bval = 1.0
     text = [f"elec-smearing {btype} {bval}"]
@@ -45,7 +45,7 @@ def test_get_broadeningvars():
 
 
 def test_get_truncationvars():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     joutslice.is_bgw = True
     with pytest.raises(ValueError, match="BGW slab Coulomb truncation must be along z!"):
         joutslice._get_truncationvars(["coulomb-interaction Slab 010"])
@@ -61,7 +61,7 @@ def test_get_truncationvars():
 
 
 def test_get_rho_cutoff():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     text = ["elec-cutoff 1.0"]
     joutslice.pwcut = None
     rhocut = joutslice._get_rho_cutoff(text)
@@ -70,7 +70,7 @@ def test_get_rho_cutoff():
 
 
 def test_get_eigstats_varsdict():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     evardict = joutslice._get_eigstats_varsdict([])
     for key in evardict:
         assert evardict[key] is None
@@ -89,14 +89,14 @@ def test_get_eigstats_varsdict():
 
 
 def test_get_pp_type():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     assert joutslice._get_pp_type(["Reading pseudopotential file root/PAW:"]) is None
     assert joutslice._get_pp_type(["Reading pseudopotential file not_SG15/GBRV"]) == "GBRV"
     assert joutslice._get_pp_type(["Reading pseudopotential file not_GBRV/SG15"]) == "SG15"
 
 
 def test_set_pseudo_vars_t1():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     # 6 instances of "reading pseudopotential file" since all possible test files have less than 6 atom types
     text = [
         "Reading pseudopotential file not_SG15/GBRV",
@@ -130,14 +130,14 @@ def test_set_pseudo_vars_t1():
 
 
 def test_set_orb_fillings_nobroad():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     joutslice._set_orb_fillings_nobroad(1)
     assert joutslice.homo_filling == pytest.approx(2)
     assert joutslice.lumo_filling == pytest.approx(0)
 
 
 def test_set_orb_fillings_broad():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     joutslice.lumo = None
     with pytest.raises(ValueError, match="Cannot set orbital fillings with broadening with self.lumo as None"):
         joutslice._set_orb_fillings()
@@ -157,21 +157,21 @@ def test_set_orb_fillings_broad():
 
 
 def test_set_lattice_vars():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     joutslice.jstrucs = None
     with pytest.raises(ValueError, match="No structures found in out file."):
         joutslice._set_lattice_vars([])
 
 
 def test_set_ecomponents():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     joutslice.jstrucs = None
     with pytest.raises(ValueError, match="No structures found in out file."):
         joutslice._set_ecomponents([])
 
 
 def test_calculate_filling():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     broadening = 1.0
     eig = 0.5
     efermi = 0.6
@@ -189,7 +189,7 @@ def test_calculate_filling():
 
 
 def test_determine_is_metal():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     for varname in ["lumo_filling", "homo_filling", "nspin"]:
         setattr(joutslice, varname, None)
         with pytest.raises(ValueError, match=f"Cannot determine if system is metal - self.{varname} undefined"):
@@ -197,13 +197,13 @@ def test_determine_is_metal():
 
 
 def test_write():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     with pytest.raises(NotImplementedError):
         joutslice.write()
 
 
 def test_as_dict():
-    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1)
+    joutslice = JDFTXOutfileSlice._from_out_slice(ex_slice1, [], [])
     out_dict = joutslice.as_dict()
     assert isinstance(out_dict, dict)
 
@@ -219,7 +219,7 @@ def test_none_on_partial(ex_slice: list[str]):
     freq = 5
     for i in range(int(len(ex_slice) / freq)):
         test_slice = ex_slice[: -(i * freq)]
-        joutslice = JDFTXOutfileSlice._from_out_slice(test_slice, none_on_error=True)
+        joutslice = JDFTXOutfileSlice._from_out_slice(test_slice, [], [], none_on_error=True)
         if should_be_parsable_out_slice(test_slice):
             assert isinstance(joutslice, JDFTXOutfileSlice | None)
         else:

--- a/tests/io/jdftx/test_repr_out.py
+++ b/tests/io/jdftx/test_repr_out.py
@@ -31,8 +31,13 @@ if TYPE_CHECKING:
     ("init_meth", "init_var", "add_checks"),
     [
         (lambda x: JDFTXOutfile.from_file(x), example_sp_outfile_path, lambda dir_repr: None),
-        (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
-        (lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"), ex_outfileslice1, lambda dir_repr: None),
+        (lambda x: JDFTXOutfileSlice._from_out_slice(x, [], []), ex_outfileslice1, lambda dir_repr: None),
+        # (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
+        (
+            lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"),
+            ex_outfileslice1,
+            lambda dir_repr: None,
+        ),
         (lambda x: JOutStructure._from_text_slice(x, opt_type="lattice"), ex_jstruc_slice1, lambda dir_repr: None),
         (lambda x: JElStep._from_lines_collect(x, "ElecMinimize", "F"), ex_jstep_lines1, lambda dir_repr: None),
         (
@@ -59,8 +64,13 @@ def test_dir_repr(init_meth: Callable, init_var: Any, add_checks: Callable) -> N
     ("init_meth", "init_var", "add_checks"),
     [
         (lambda x: JDFTXOutfile.from_file(x), example_sp_outfile_path, lambda dir_repr: None),
-        (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
-        (lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"), ex_outfileslice1, lambda dir_repr: None),
+        (lambda x: JDFTXOutfileSlice._from_out_slice(x, [], []), ex_outfileslice1, lambda dir_repr: None),
+        # (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
+        (
+            lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"),
+            ex_outfileslice1,
+            lambda dir_repr: None,
+        ),
         (lambda x: JOutStructure._from_text_slice(x, opt_type="lattice"), ex_jstruc_slice1, lambda dir_repr: None),
         (lambda x: JElStep._from_lines_collect(x, "ElecMinimize", "F"), ex_jstep_lines1, lambda dir_repr: None),
         (
@@ -87,8 +97,13 @@ def test_repr_repr(init_meth: Callable, init_var: Any, add_checks: Callable) -> 
     ("init_meth", "init_var", "add_checks"),
     [
         (lambda x: JDFTXOutfile.from_file(x), example_sp_outfile_path, lambda dir_repr: None),
-        (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
-        (lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"), ex_outfileslice1, lambda dir_repr: None),
+        (lambda x: JDFTXOutfileSlice._from_out_slice(x, [], []), ex_outfileslice1, lambda dir_repr: None),
+        # (JDFTXOutfileSlice._from_out_slice, ex_outfileslice1, lambda dir_repr: None),
+        (
+            lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"),
+            ex_outfileslice1,
+            lambda dir_repr: None,
+        ),
         (lambda x: JOutStructure._from_text_slice(x, opt_type="lattice"), ex_jstruc_slice1, lambda dir_repr: None),
         (lambda x: JElStep._from_lines_collect(x, "ElecMinimize", "F"), ex_jstep_lines1, lambda dir_repr: None),
         (
@@ -108,8 +123,16 @@ def test_str_repr(init_meth: Callable, init_var: Any, add_checks: Callable) -> N
     ("init_meth", "init_var", "add_checks"),
     [
         (lambda x: JDFTXOutfile.from_file(x), example_sp_outfile_path, lambda dir_repr: None),
-        (lambda x: JDFTXOutfileSlice._from_out_slice(x, none_on_error=False), ex_outfileslice1, lambda dir_repr: None),
-        (lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"), ex_outfileslice1, lambda dir_repr: None),
+        (
+            lambda x: JDFTXOutfileSlice._from_out_slice(x, [], [], none_on_error=False),
+            ex_outfileslice1,
+            lambda dir_repr: None,
+        ),
+        (
+            lambda x: JOutStructures._from_out_slice(x, opt_type="lattice"),
+            ex_outfileslice1,
+            lambda dir_repr: None,
+        ),
         (lambda x: JOutStructure._from_text_slice(x, opt_type="lattice"), ex_jstruc_slice1, lambda dir_repr: None),
         (lambda x: JElStep._from_lines_collect(x, "ElecMinimize", "F"), ex_jstep_lines1, lambda dir_repr: None),
         (


### PR DESCRIPTION
- `JDFTXInfile.read_line` function for more user-friendly method of adding tags
- Very choppy "nan"-stripping method for removing tags with "nan" values
-- This is an issue in the ionic-dynamics tag, as parameters that aren't being used (ie P0 for a thermostat simulation) will be stored as "nan" and printed in the inputs summary. This causes bad re-start in files if these tags arent stripped from the `JDFTXInfile` initialized from this inputs summary
-- The better approach (TODO) is to skip these tags altogether in the `JDFTXInfile` initialization
- Changing `structure: Structure`/`trajectory: Trajectory` class variables into properties (these become expensive for larger out files)
- `pop_none_slices` keyword argument for `JDFTXOutfile` for automatically popping `JDFTXOutfileSlice`s that failed to parse (and get stored as None)